### PR TITLE
Fix tooltip not showing on first position

### DIFF
--- a/src/tooltip.ts
+++ b/src/tooltip.ts
@@ -234,7 +234,7 @@ const tooltipPlugin = ViewPlugin.fromClass(class {
       // Hide tooltips that are outside of the editor.
       if (!pos || pos.bottom <= Math.max(editor.top, space.top) ||
           pos.top >= Math.min(editor.bottom, space.bottom) ||
-          pos.right <= Math.max(editor.left, space.left) ||
+          pos.right < Math.max(editor.left, space.left) ||
           pos.left >= Math.min(editor.right, space.right)) {
         dom.style.top = Outside
         continue


### PR DESCRIPTION
I have an editor with 0 padding and absolutely positioned tooltips. The autocomplete tooltip was not showing because its x position was the same as editor left. This should be strict inequality. I don't have a minimal repro but we could probably put it together easily. I'm not sure about the other inequalities and whether they should be fixed too.

Here's at least a demo of my UI (before the fix in this PR):

https://user-images.githubusercontent.com/1473433/150243863-00bdd80e-bad7-47bf-ba49-190eb97ebaae.mov


